### PR TITLE
Fix basepath for mirgation scripts #9

### DIFF
--- a/tools/Create-Migration.ps1
+++ b/tools/Create-Migration.ps1
@@ -57,7 +57,7 @@ try {
 
     $filename = "${uniqueNumber}_${Type}_$sanitizedName.sql"
 
-    $basePath = if ($PSScriptRoot) { $PSScriptRoot } else { Get-Location }
+    $basePath = Get-Location
     $scriptsFolder = Join-Path $basePath "FlexiForm.Database/Scripts"
     $typeSubFolder = $typeToFolderMap[$Type]
 


### PR DESCRIPTION
**PR Description:**

Fixed the `$basePath` logic to correctly determine the destination folder for migration scripts.
Previously, `$basePath` was resolving to the script's root directory (`$PSScriptRoot`), which caused migration scripts to be placed in the wrong location. Now, the path is correctly set to target the intended destination folder for migrations.
