### PR TITLE
Increase password column length #8

### DIFF
--- a/FlexiForm.Database/Scripts/Alters/Down/20250624054059670_alter_tblusers.sql
+++ b/FlexiForm.Database/Scripts/Alters/Down/20250624054059670_alter_tblusers.sql
@@ -1,0 +1,31 @@
+﻿-- Script Type    : alter
+-- Name           : 20250624054059670_alter_tblusers.sql
+-- Created At     : 2025-06-24 05:40:59 UTC (Arijit Roy)
+-- Script ID      : 20250624054059670
+-- Migration Type : Down
+
+BEGIN TRY
+    BEGIN TRANSACTION;
+
+    IF OBJECT_ID('tblUsers', 'U') IS NOT NULL
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = 'tblUsers' 
+              AND COLUMN_NAME = 'Password'
+              AND DATA_TYPE = 'VARCHAR'
+        )
+        BEGIN
+            ALTER TABLE tblUsers
+            ALTER COLUMN [Password]
+            VARCHAR(32) NOT NULL;
+        END
+    END
+
+    COMMIT;
+END TRY
+BEGIN CATCH
+    ROLLBACK;
+    PRINT 'An error occurred: ' + ERROR_MESSAGE();
+END CATCH

--- a/FlexiForm.Database/Scripts/Alters/Up/20250624054059670_alter_tblusers.sql
+++ b/FlexiForm.Database/Scripts/Alters/Up/20250624054059670_alter_tblusers.sql
@@ -1,0 +1,31 @@
+﻿-- Script Type    : alter
+-- Name           : 20250624054059670_alter_tblusers.sql
+-- Created At     : 2025-06-24 05:40:59 UTC (Arijit Roy)
+-- Script ID      : 20250624054059670
+-- Migration Type : Up
+
+BEGIN TRY
+    BEGIN TRANSACTION;
+
+    IF OBJECT_ID('tblUsers', 'U') IS NOT NULL
+    BEGIN
+        IF EXISTS (
+            SELECT 1
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = 'tblUsers' 
+              AND COLUMN_NAME = 'Password'
+              AND DATA_TYPE = 'VARCHAR'
+        )
+        BEGIN
+            ALTER TABLE tblUsers
+            ALTER COLUMN [Password]
+            VARCHAR(64) NOT NULL;
+        END
+    END
+
+    COMMIT;
+END TRY
+BEGIN CATCH
+    ROLLBACK;
+    PRINT 'An error occurred: ' + ERROR_MESSAGE();
+END CATCH


### PR DESCRIPTION
#### 📌 Summary

This PR updates the **database schema** to increase the length of the `Password` column to **64 bytes**. The change is intended to support longer hashed values and prevent truncation issues.

#### 🛠️ Changes Made

* Altered the `Password` column definition via a new `Alter` migration script
* No application-layer or logic changes involved in this PR

#### 🎯 Purpose

* Prevent value truncation for longer, hashed passwords
* Ensure compatibility with secure authentication standards (e.g., SHA-256)
* Improve data integrity at the DB level

#### ✅ Validation

* Schema successfully updated via migration
* Verified column length reflects updated definition
* Existing data remains intact and unaffected

#### 📝 Notes

This is a **DB-only change**. Application logic can remain unchanged unless future enhancements require password handling updates.